### PR TITLE
Config Option For Debug Logs

### DIFF
--- a/loaforcsSoundAPI/API/SoundReplacementAPI.cs
+++ b/loaforcsSoundAPI/API/SoundReplacementAPI.cs
@@ -32,7 +32,10 @@ namespace loaforcsSoundAPI.API {
         }
 
         public static bool MatchStrings(string a, string b) {
-            SoundPlugin.logger.LogDebug($"{a} == {b}?");
+            if (SoundPluginConfig.ENABLE_DEBUGLOGGING.Value)
+            {
+                SoundPlugin.logger.LogDebug($"{a} == {b}?");
+            }
             string[] testing = a.Split(":");
             string[] expected = b.Split(":");
             if (expected[0] != "*" && expected[0] != testing[0]) return false; // parent gameobject mismatch

--- a/loaforcsSoundAPI/Patches/AudioSourcePatch.cs
+++ b/loaforcsSoundAPI/Patches/AudioSourcePatch.cs
@@ -88,7 +88,10 @@ namespace loaforcsSoundAPI.Patches {
         internal static AudioClip GetReplacementClip(string name, out SoundReplacementCollection collection) {
             collection = null;
             if(name == null) return null;
-            SoundPlugin.logger.LogDebug($"Getting replacement for: {name} (doing top level search for {name.Split(":")[2]})");
+            if (SoundPluginConfig.ENABLE_DEBUGLOGGING.Value)
+            {
+                SoundPlugin.logger.LogDebug($"Getting replacement for: {name} (doing top level search for {name.Split(":")[2]})");
+            }
 
             if (!SoundReplacementAPI.SoundReplacements.ContainsKey(name.Split(":")[2])) { return null; }
 

--- a/loaforcsSoundAPI/SoundPlugin.cs
+++ b/loaforcsSoundAPI/SoundPlugin.cs
@@ -65,7 +65,7 @@ namespace loaforcsSoundAPI {
                 // Combine the current subdirectory with the file name
                 foreach (string subsubdirectory in Directory.GetDirectories(subdirectory)) {
                     string subfilePath = Path.Combine(subsubdirectory, "sound_pack.json");
-                    Logger.LogDebug(subsubdirectory);
+                    logger.LogDebug(subsubdirectory);
 
                     // Check if the file exists
                     if (File.Exists(subfilePath)) {

--- a/loaforcsSoundAPI/SoundPluginConfig.cs
+++ b/loaforcsSoundAPI/SoundPluginConfig.cs
@@ -7,6 +7,7 @@ namespace loaforcsSoundAPI {
     internal class SoundPluginConfig {
         internal static ConfigEntry<bool> ENABLE_MULTITHREADING;
         internal static ConfigEntry<int> THREADPOOL_MAX_THREADS;
+        internal static ConfigEntry<bool> ENABLE_DEBUGLOGGING;
         internal SoundPluginConfig(ConfigFile config) {
             ENABLE_MULTITHREADING = config.Bind("SoundLoading", "Multithreading", true, 
                 "Whether or not to use multithreading when loading a sound pack. If you haven't been told that you should disable multithreading, you probably don't need to!"+
@@ -16,6 +17,10 @@ namespace loaforcsSoundAPI {
             THREADPOOL_MAX_THREADS = config.Bind("SoundLoading", "MaxThreadsInThreadPool", 32, 
                 "Max amount of threads the loading thread pool can create at once.\n"+
                 "Increasing this number will decrease loading of non-startup packs but may be unsupported by your CPU."
+                );
+
+            ENABLE_DEBUGLOGGING = config.Bind("Logging", "LogSounds", false,
+                "Whether or not to show logs for sounds playing. Only recommended whilst developing sound mods."
                 );
         }
     }


### PR DESCRIPTION
- Added a config option to enable the logging for sounds playing since it's pretty spammy whilst trying to test other mods (this is disabled by default).
- Fixed one of the debug logs using the base BepInEx logger instead of the one that's initialised in the code.